### PR TITLE
Handle non-namespaced resources

### DIFF
--- a/kustomize.libsonnet
+++ b/kustomize.libsonnet
@@ -11,7 +11,38 @@
   applyList(funcs):: function(o) std.foldl(function(result, f) f(result), funcs, o),
 
   // Add a namespace.
-  namespace(ns):: function(o) o + {metadata+: {namespace: ns}},
+  namespace(ns):: function(o) (
+    // Exclude non-namespaced resources
+    // See kubectl api-resources --namespaced=false
+    local nonNamespaced = std.set([
+      "ComponentStatus",
+      "Namespace",
+      "Node",
+      "PersistentVolume",
+      "MutatingWebhookConfiguration",
+      "ValidatingWebhookConfiguration",
+      "CustomResourceDefinition",
+      "APIService",
+      "TokenReview",
+      "SelfSubjectAccessReview",
+      "SelfSubjectRulesReview",
+      "SubjectAccessReview",
+      "CertificateSigningRequest",
+      "PodSecurityPolicy",
+      "ClusterRoleBinding",
+      "ClusterRole",
+      "PriorityClass",
+      "CSIDriver",
+      "CSINode",
+      "StorageClass",
+      "VolumeAttachment",
+    ]);
+    if !std.setMember(o.kind, nonNamespaced) then o + {
+      metadata+: {
+        namespace: ns
+      }
+    } else o
+  ),
 
   // Prepend the value to the resource name.
   namePrefix(p):: function(o) o + {metadata+: {name: p + super.name}},


### PR DESCRIPTION
Excludes non-namespaced API resources from the `namespace` combinator.

See:
`kubectl api-resources --namespaced=false`
