### PR TITLE
Fix image tag extraction in kustomize.images

### DIFF
--- a/kustomize.libsonnet
+++ b/kustomize.libsonnet
@@ -218,7 +218,7 @@
     local newImage(old, img) = (
       local nametag = std.split(old, ":");
       local name = nametag[0];
-      local tag = if std.length(nametag) > 1 then nametag else "latest";
+      local tag = if std.length(nametag) > 1 then nametag[1] else "latest";
       if name == img.name then (
         local newName = if std.objectHas(img, "newName") then img.newName else name;
         local newTag = if std.objectHas(img, "newTag") then img.newTag else tag;


### PR DESCRIPTION
When extracting the tag from an image when a `:tag` is present, the
`images.newImage()` function was setting the tag to the array instead of
the tag element. Use `nametag[1]` instead of `nametag` to fix that.